### PR TITLE
Update translation_it with input_GS_AXIS_SHIFT

### DIFF
--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -3,31 +3,31 @@
     <translationContributors>zed636</translationContributors>
 
     <texts>
-        <text name="configuration_buyableGPS" text="Sistema di Posizionamento Globale"/> <!-- Global Positioning System -->
+        <text name="configuration_buyableGPS" text="Sistema GPS"/> <!-- Global Positioning System -->
         <text name="configuration_buyableGPS_withoutGPS" text="No"/> <!-- No -->
         <text name="configuration_buyableGPS_withGPS" text="Si"/> <!-- Yes -->
 
-        <!--Inputs-->
+        <!-- Inputs -->
         <text name="input_GS_SHOW_UI" text="Mostra menu Guidance Steering"/> <!-- Show guidance steering menu -->
         <text name="input_GS_SET_AUTO_WIDTH" text="Larghezza automatica"/> <!-- Auto width -->
 
-        <!--TODO: input_GS_AXIS_SHIFT-->
-        <text name="input_GS_AXIS_SHIFT" text="Shift track"/> <!-- Shift track -->
-        <text name="input_GS_AXIS_WIDTH" text="Change width"/> <!-- Change width -->
+        <!-- input_GS_AXIS_SHIFT -->
+        <text name="input_GS_AXIS_SHIFT" text="Cambia traccia"/> <!-- Shift track -->
+        <text name="input_GS_AXIS_WIDTH" text="Cambia larghezza"/> <!-- Change width -->
 
         <text name="input_GS_ENABLE_STEERING" text="Attiva Guidance Steering"/> <!-- Steering guidance -->
         <text name="input_GS_SETPOINT" text="Imposta il punto di direzione"/> <!-- Set guidance point -->
         <text name="input_GS_TOGGLE_TERRAIN_ANGLE_SNAP" text="Aggancia all'angolo del terreno"/> <!-- Snap to terrain angle -->
         <text name="input_GS_TURN_STEERING" text="Imposta direzione dello sterzo"/> <!-- Set steering direction -->
 
-        <!--Warnings-->
+        <!-- Warnings -->
         <text name="guidanceSteering_warning_dropDistance"
               text="Guidare almeno 15m per impostare il punto B. Distanza attualmente percorsa: %.2f"/> <!-- Drive at least 15m in order to set point B. Current traveled distance: %.2f -->
         <text name="guidanceSteering_warning_setWidth"
               text="Si prega di impostare prima una larghezza di lavoro!"/> <!-- Please set a working width first! -->
         <text name="guidanceSteering_warning_createTrackFirst" text="Si prega di creare o caricare una traccia prima di abilitare Guidance Steering!"/> <!-- Please create or load a track first before enabling guidance steering! -->
 
-        <!--GUI-->
+        <!-- GUI -->
         <text name="guidanceSteering_ui_settings" text="Impostazioni Guidance Steering"/> <!-- Guidance settings -->
         <text name="guidanceSteering_ui_strategy" text="Strategia Guidance Steering"/> <!-- Guidance strategy -->
 
@@ -38,7 +38,7 @@
         <text name="guidanceSteering_strategyMethod_autoB" text="Auto B"/> <!-- Auto B -->
         <text name="guidanceSteering_strategyMethod_aPlusHeading" text="A+testata"/> <!-- A+Heading -->
 
-        <!--Tooltips-->
+        <!-- Tooltips -->
         <text name="guidanceSteering_tooltip_showLines"
               text="Aiuta la tua visuale mostrando le linee di guida"/> <!-- Support your visuals by showing the guidance lines -->
         <text name="guidanceSteering_tooltip_terrainAngleSnap"
@@ -56,10 +56,10 @@
         <text name="guidanceSteering_tooltip_currentTrack" text="Seleziona la traccia corrente da usare"/> <!-- Select the current track to use -->
         <text name="guidanceSteering_tooltip_cardinals" text="Imposta i punti cardinali"/> <!-- Set the cardinal points -->
 
-        <!--Warning tooltip-->
+        <!-- Warning tooltip -->
         <text name="guidanceSteering_tooltip_trackAlreadyExists" text="Nome della traccia: %s esiste già!"/> <!-- Track name: %s already exists! -->
 
-        <!--Settings-->
+        <!-- Settings -->
         <text name="guidanceSteering_setting_showLines" text="Mostra linee"/> <!-- Show lines -->
         <text name="guidanceSteering_setting_terrainAngleSnap" text="Aggancia l'angolo del terreno"/> <!-- Snap terrain angle -->
         <text name="guidanceSteering_setting_enableGuidanceSteering" text="Abilita Guidance Steering"/> <!-- Enable guidance steering -->

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -12,8 +12,10 @@
         <text name="input_GS_SET_AUTO_WIDTH" text="Larghezza automatica"/> <!-- Auto width -->
 
         <!-- input_GS_AXIS_SHIFT -->
-        <text name="input_GS_AXIS_SHIFT" text="Cambia traccia"/> <!-- Shift track -->
-        <text name="input_GS_AXIS_WIDTH" text="Cambia larghezza"/> <!-- Change width -->
+        <text name="input_GS_AXIS_SHIFT_1" text="Sposta traccia a destra"/> <!-- Shift track right -->
+        <text name="input_GS_AXIS_SHIFT_2" text="Sposta traccia a sinistra"/> <!-- Shift track left -->
+        <text name="input_GS_AXIS_WIDTH_1" text="Aumenta larghezza traccia"/> <!-- Increase track width -->
+        <text name="input_GS_AXIS_WIDTH_2" text="Diminuisci larghezza traccia"/> <!-- Decrease track width -->
 
         <text name="input_GS_ENABLE_STEERING" text="Attiva Guidance Steering"/> <!-- Steering guidance -->
         <text name="input_GS_SETPOINT" text="Imposta il punto di direzione"/> <!-- Set guidance point -->

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -3,7 +3,7 @@
     <translationContributors>zed636</translationContributors>
 
     <texts>
-        <text name="configuration_buyableGPS" text="Sistema GPS"/> <!-- Global Positioning System -->
+        <text name="configuration_buyableGPS" text="GPS"/> <!-- Global Positioning System -->
         <text name="configuration_buyableGPS_withoutGPS" text="No"/> <!-- No -->
         <text name="configuration_buyableGPS_withGPS" text="Si"/> <!-- Yes -->
 


### PR DESCRIPTION
![fsscreen_2019_02_12_15_00_43](https://user-images.githubusercontent.com/19471664/52640723-72c6fa80-2ed7-11e9-83b1-5ff8a13a69d4.png)
"Sistema di Posizionamento Globale" - Global Positioning System is too long, it overlaps with the display of the price in the store. I can use the abbreviation like GPS or GPS System (Sistema GPS)?