### PR TITLE
Allowing cars category to support using GPS in trucks like the TLX Mods

### DIFF
--- a/src/loader.lua
+++ b/src/loader.lua
@@ -210,7 +210,6 @@ local disallowedCategories = {
     ["WOOD"] = false,
     ["BELTS"] = false,
     ["LEVELER"] = false,
-    ["CARS"] = false,
     ["DECORATION"] = false,
     ["PLACEABLEMISC"] = false,
     ["PLACEABLEMISC"] = false,


### PR DESCRIPTION
I often use the TLX mod trucks for various activities including field work. It would be very helpful for this mod to support purchasing and using GPS on these types of vehicles. I have been using this modification to guidanceSteering successfully to accomplish this and it would be great if it could be merged into the source.