### PR TITLE
Allow big offsets

### DIFF
--- a/src/gui/frames/GuidanceSteeringSettingsFrame.lua
+++ b/src/gui/frames/GuidanceSteeringSettingsFrame.lua
@@ -287,8 +287,7 @@ function GuidanceSteeringSettingsFrame:changeOffsetWidth(direction)
     local state = self.guidanceSteeringOffsetIncrementElement:getState()
     local increment = GuidanceSteeringSettingsFrame.INCREMENTS[state] * direction
 
-    local threshold = self.currentGuidanceWidth * 0.5
-    self.currentGuidanceOffset = MathUtil.clamp(self.currentGuidanceOffset + increment, -threshold, threshold)
+    self.currentGuidanceOffset = self.currentGuidanceOffset + increment
     self.guidanceSteeringOffsetWidthText:setText(self:getFormattedUnitLength(self.currentGuidanceOffset))
 
     self:updateOffsetUVs()

--- a/src/vehicles/GlobalPositioningSystem.lua
+++ b/src/vehicles/GlobalPositioningSystem.lua
@@ -581,10 +581,12 @@ function GlobalPositioningSystem:onUpdate(dt)
         if data.isReverseDriving then
             data.snapDirectionMultiplier = -data.snapDirectionMultiplier
         end
+		
+        local snapFactor = spec.autoInvertOffset and data.snapDirectionMultiplier or 1.0
 
         if data.width ~= 0 then
             local lineAlpha = GuidanceUtil.getAProjectOnLineParameter(z, x, lineZ, lineX, lineDirX, lineDirZ) / data.width
-            data.currentLane = MathUtil.round( lineAlpha - (data.offsetWidth * data.snapDirectionMultiplier / data.width))
+            data.currentLane = MathUtil.round( lineAlpha - (data.offsetWidth * snapFactor / data.width))
             data.alphaRad = lineAlpha - data.currentLane
         end
     end

--- a/src/vehicles/GlobalPositioningSystem.lua
+++ b/src/vehicles/GlobalPositioningSystem.lua
@@ -560,12 +560,6 @@ function GlobalPositioningSystem:onUpdate(dt)
 
         local lineDirX, lineDirZ, lineX, lineZ = unpack(data.snapDirection)
 
-        if data.width ~= 0 then
-            local lineAlpha = GuidanceUtil.getAProjectOnLineParameter(z, x, lineZ, lineX, lineDirX, lineDirZ) / data.width
-            data.currentLane = MathUtil.round(lineAlpha)
-            data.alphaRad = lineAlpha - data.currentLane
-        end
-
         -- Todo: straight strategy prob needs this?
         local dirX, _, dirZ = localDirectionToWorld(guidanceNode, worldDirectionToLocal(guidanceNode, lineDirX, 0, lineDirZ))
         --                local dirX, dirZ = lineDirX, lineDirZ
@@ -586,6 +580,12 @@ function GlobalPositioningSystem:onUpdate(dt)
 
         if data.isReverseDriving then
             data.snapDirectionMultiplier = -data.snapDirectionMultiplier
+        end
+
+        if data.width ~= 0 then
+            local lineAlpha = GuidanceUtil.getAProjectOnLineParameter(z, x, lineZ, lineX, lineDirX, lineDirZ) / data.width
+            data.currentLane = MathUtil.round( lineAlpha - (data.offsetWidth * data.snapDirectionMultiplier / data.width))
+            data.alphaRad = lineAlpha - data.currentLane
         end
     end
 


### PR DESCRIPTION
Hi!

I always wanted the ability to use offsets bigger than half than my working width. For some implements this is necessary.

With these changes the current lane is now tracked relative to the offset line instead of the middle of the lane.
Of course the threshold in the GUI also needs to be removed for this to make any sense.

I did this for my self for mowing, but thought you might want to add it as well.
Not sure if this feature was intentionally not implemented before, just check it out if you want.

I did some testing for my self, and everything seems to be working as intended including offset reversal.